### PR TITLE
Computation of the chemical potential was improved for any ensemble

### DIFF
--- a/src/MC.cpp
+++ b/src/MC.cpp
@@ -18,9 +18,12 @@ MC::MC(void){
 	stats.nVolChanges = 0;
 	for (i=0; i<MAXBOX; i++){
 		stats.acceptanceVol[i] = stats.rejectionVol[i] = 0;
-		stats.widomInsertions[i] = 0;
 		stats.acceptance[i] = stats.rejection[i] = stats.nDisplacements[i] = 0;
-		for (j=0; j<MAXSPECIES; j++) stats.widom[i][j] = 0.;
+		for (j=0; j<MAXSPECIES; j++){
+			stats.barC[i][j] = 1.;
+			stats.widomInsertions[i][j] = stats.widomDeletions[i][j] = 1;
+			stats.widomInsert[i][j] = stats.widomDelete[i][j] = 0.;
+		}
 	}
 	for (i=0; i<=NBINS; i++) stats.rdf[i] = 0.;
 	sim.projName = "";
@@ -84,12 +87,16 @@ void MC::ResetStats(void){
 	stats.nVolChanges = 1;
 	stats.acceptSwap = stats.rejectSwap = 0;
 	stats.nSwaps = 1;
-	for (i=0; i<thermoSys.nSpecies; i++) stats.widomInsertions[i] = 0;
 	for (i=0; i<thermoSys.nBoxes; i++){
+		for (int j=0; j<thermoSys.nSpecies; j++){
+			stats.barC[i][j] = box[i].fluid[j].muEx - thermoSys.temp*log(stats.widomInsertions[i][j]/stats.widomDeletions[i][j]);
+			stats.barC[i][j] = 1.;
+			stats.widomInsertions[i][j] = stats.widomDeletions[i][j] = 1;
+			stats.widomInsert[i][j] = stats.widomDelete[i][j] = 0.;
+		}
 		stats.acceptanceVol[i] = stats.rejectionVol[i] = 0;
 		stats.acceptance[i] = stats.rejection[i] = 0;
 		stats.nDisplacements[i] = 1;
-		for (int j=0; j<thermoSys.nSpecies; j++) stats.widom[i][j] = 0.;
 	}
 }
 

--- a/src/MC.h
+++ b/src/MC.h
@@ -35,8 +35,8 @@ class MC {
 			int acceptance[MAXBOX], rejection[MAXBOX], nDisplacements[MAXBOX];
 			int acceptanceVol[MAXBOX], rejectionVol[MAXBOX], nVolChanges;
 			int acceptSwap, rejectSwap, nSwaps;
-			int widomInsertions[MAXBOX];
-			double binWidth, widom[MAXBOX][MAXSPECIES], rdf[NBINS+1];
+			int widomInsertions[MAXBOX][MAXSPECIES], widomDeletions[MAXBOX][MAXSPECIES];
+			double binWidth, barC[MAXBOX][MAXSPECIES], widomInsert[MAXBOX][MAXSPECIES], widomDelete[MAXBOX][MAXSPECIES], rdf[NBINS+1];
 		} stats;
 		struct Simulation{
 			bool printTrajectory;
@@ -105,6 +105,7 @@ class MC {
 		void ComputeChemicalPotential(void);
 		void EnergyOfParticle(int, int, int);
 		double Random(void){return dis(engine);} //random num. in the interval [0,1).
+		double BarWeight(double, double);
 		double ComputeVolume(Box);
 		double ComputeBoxWidth(Box, double);
 		void BoxEnergy(int);


### PR DESCRIPTION
The BAR method substitutes the brute test particle insertion. It is applicable to any ensemble: NVT, NPT, GEMC-NPT, and GEMC-NVT.

Modified files:
- MC.cpp/MC.h
- moves.cpp